### PR TITLE
Fix: class not found error when calling e.g. local_rsync_remove_all_s…

### DIFF
--- a/section.php
+++ b/section.php
@@ -25,6 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->libdir . '/externallib.php');
 require_once($CFG->dirroot. '/course/lib.php');
 require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
 require_once($CFG->dirroot . "/backup/util/includes/restore_includes.php");


### PR DESCRIPTION
…ections